### PR TITLE
new supervisor logic with single reader

### DIFF
--- a/src/core/Supervisor.zig
+++ b/src/core/Supervisor.zig
@@ -109,6 +109,7 @@ fn selectFirstDone(io: Io, futures: []Io.Future(HandlerReturn), count: usize) !u
     // given we first convert our futures to *Io.AnyFuture
     var any_futures: [MAX_INFLIGHT]*Io.AnyFuture = undefined;
     for (futures[0..count], 0..) |*f, i| {
+        // *Io.AnyFuture is at .any_future, else null value implies the future is done
         any_futures[i] = f.any_future orelse return i;
     }
     // io.vtable.select blocks until one of the futures has a result ready


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch supervisor to a single-reader loop that polls and asynchronously dispatches seccomp notifications. This prevents kernel deadlocks and keeps parallel syscall handling.

- **Bug Fixes**
  - Use one reader for recv to avoid a kernel bug that can block forever when the seccomp filter dies.
  - Poll notify_fd before recv to catch POLLHUP and exit cleanly instead of hanging.

- **Refactors**
  - Replace worker threads with bounded async dispatch (MAX_INFLIGHT=8) to the IO pool, selecting the first completed future to free a slot.
  - Add handleNotif() and await all in-flight tasks on shutdown.

<sup>Written for commit be198dbe1d8c92136aafe5d84b959b118c459aea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

