### PR TITLE
implement socket and socketpair

### DIFF
--- a/src/core/main.zig
+++ b/src/core/main.zig
@@ -44,6 +44,8 @@ test {
     _ = @import("virtual/syscall/handlers/fchdir.zig");
     _ = @import("virtual/syscall/handlers/faccessat.zig");
     _ = @import("virtual/syscall/handlers/pipe2.zig");
+    _ = @import("virtual/syscall/handlers/socket.zig");
+    _ = @import("virtual/syscall/handlers/socketpair.zig");
     _ = @import("virtual/syscall/e2e_test.zig");
     _ = @import("virtual/OverlayRoot.zig");
     _ = @import("virtual/fs/backend/passthrough.zig");

--- a/src/core/virtual/syscall/handlers/socket.zig
+++ b/src/core/virtual/syscall/handlers/socket.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const linux = std.os.linux;
+const Thread = @import("../../proc/Thread.zig");
+const AbsTid = Thread.AbsTid;
+const File = @import("../../fs/File.zig");
+const Supervisor = @import("../../../Supervisor.zig");
+const replySuccess = @import("../../../seccomp/notif.zig").replySuccess;
+const replyErr = @import("../../../seccomp/notif.zig").replyErr;
+
+pub fn handle(notif: linux.SECCOMP.notif, supervisor: *Supervisor) linux.SECCOMP.notif_resp {
+    const logger = supervisor.logger;
+    const allocator = supervisor.allocator;
+
+    const caller_tid: AbsTid = @intCast(notif.pid);
+    const domain: u32 = @truncate(notif.data.arg0);
+    const sock_type: u32 = @truncate(notif.data.arg1);
+    const protocol: u32 = @truncate(notif.data.arg2);
+
+    const cloexec = sock_type & linux.SOCK.CLOEXEC != 0;
+
+    // Create the kernel socket
+    const rc = linux.socket(domain, sock_type, protocol);
+    const errno = linux.errno(rc);
+    if (errno != .SUCCESS) {
+        logger.log("socket: kernel socket failed: {s}", .{@tagName(errno)});
+        return replyErr(notif.id, errno);
+    }
+    const kernel_fd: i32 = @intCast(rc);
+
+    // Wrap as passthrough File
+    const file = File.init(allocator, .{ .passthrough = .{ .fd = kernel_fd } }) catch {
+        _ = std.posix.system.close(kernel_fd);
+        logger.log("socket: failed to alloc File", .{});
+        return replyErr(notif.id, .NOMEM);
+    };
+
+    // Register in the caller's FdTable
+    supervisor.mutex.lockUncancelable(supervisor.io);
+    defer supervisor.mutex.unlock(supervisor.io);
+
+    const caller = supervisor.guest_threads.get(caller_tid) catch |err| {
+        file.unref();
+        logger.log("socket: Thread not found for tid={d}: {}", .{ caller_tid, err });
+        return replyErr(notif.id, .SRCH);
+    };
+
+    const vfd = caller.fd_table.insert(file, .{ .cloexec = cloexec }) catch {
+        file.unref();
+        logger.log("socket: failed to insert fd", .{});
+        return replyErr(notif.id, .MFILE);
+    };
+
+    logger.log("socket: created vfd={d}", .{vfd});
+    return replySuccess(notif.id, vfd);
+}
+
+const testing = std.testing;
+const makeNotif = @import("../../../seccomp/notif.zig").makeNotif;
+const isError = @import("../../../seccomp/notif.zig").isError;
+const LogBuffer = @import("../../../LogBuffer.zig");
+const generateUid = @import("../../../setup.zig").generateUid;
+
+test "socket creates a virtual fd" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    const notif = makeNotif(.socket, .{
+        .pid = init_tid,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM,
+        .arg2 = 0,
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(!isError(resp));
+
+    const vfd: i32 = @intCast(resp.val);
+    try testing.expect(vfd >= 3);
+
+    const caller = supervisor.guest_threads.lookup.get(init_tid).?;
+    const file_ref = caller.fd_table.get_ref(vfd);
+    defer if (file_ref) |f| f.unref();
+    try testing.expect(file_ref != null);
+}
+
+test "socket with SOCK_CLOEXEC sets cloexec flag" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    const notif = makeNotif(.socket, .{
+        .pid = init_tid,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM | linux.SOCK.CLOEXEC,
+        .arg2 = 0,
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(!isError(resp));
+
+    const vfd: i32 = @intCast(resp.val);
+    const caller = supervisor.guest_threads.lookup.get(init_tid).?;
+    try testing.expect(caller.fd_table.getCloexec(vfd));
+}
+
+test "socket unknown caller returns ESRCH" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    const notif = makeNotif(.socket, .{
+        .pid = 999,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM,
+        .arg2 = 0,
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.SRCH))), resp.@"error");
+}

--- a/src/core/virtual/syscall/handlers/socketpair.zig
+++ b/src/core/virtual/syscall/handlers/socketpair.zig
@@ -1,0 +1,185 @@
+const std = @import("std");
+const linux = std.os.linux;
+const Thread = @import("../../proc/Thread.zig");
+const AbsTid = Thread.AbsTid;
+const File = @import("../../fs/File.zig");
+const Supervisor = @import("../../../Supervisor.zig");
+const replySuccess = @import("../../../seccomp/notif.zig").replySuccess;
+const replyErr = @import("../../../seccomp/notif.zig").replyErr;
+const memory_bridge = @import("../../../utils/memory_bridge.zig");
+
+pub fn handle(notif: linux.SECCOMP.notif, supervisor: *Supervisor) linux.SECCOMP.notif_resp {
+    const logger = supervisor.logger;
+    const allocator = supervisor.allocator;
+
+    const caller_tid: AbsTid = @intCast(notif.pid);
+    const domain: u32 = @truncate(notif.data.arg0);
+    const sock_type: u32 = @truncate(notif.data.arg1);
+    const protocol: u32 = @truncate(notif.data.arg2);
+    const sv_ptr: u64 = notif.data.arg3;
+
+    const cloexec = sock_type & linux.SOCK.CLOEXEC != 0;
+
+    // Create the kernel socket pair
+    var kernel_fds: [2]i32 = undefined;
+    const rc = linux.socketpair(domain, sock_type, protocol, &kernel_fds);
+    const errno = linux.errno(rc);
+    if (errno != .SUCCESS) {
+        logger.log("socketpair: kernel socketpair failed: {s}", .{@tagName(errno)});
+        return replyErr(notif.id, errno);
+    }
+
+    // Wrap both ends as passthrough Files
+    const file0 = File.init(allocator, .{ .passthrough = .{ .fd = kernel_fds[0] } }) catch {
+        _ = std.posix.system.close(kernel_fds[0]);
+        _ = std.posix.system.close(kernel_fds[1]);
+        logger.log("socketpair: failed to alloc File 0", .{});
+        return replyErr(notif.id, .NOMEM);
+    };
+
+    const file1 = File.init(allocator, .{ .passthrough = .{ .fd = kernel_fds[1] } }) catch {
+        file0.unref();
+        _ = std.posix.system.close(kernel_fds[1]);
+        logger.log("socketpair: failed to alloc File 1", .{});
+        return replyErr(notif.id, .NOMEM);
+    };
+
+    // Register both in the caller's FdTable
+    supervisor.mutex.lockUncancelable(supervisor.io);
+    defer supervisor.mutex.unlock(supervisor.io);
+
+    const caller = supervisor.guest_threads.get(caller_tid) catch |err| {
+        file0.unref();
+        file1.unref();
+        logger.log("socketpair: Thread not found for tid={d}: {}", .{ caller_tid, err });
+        return replyErr(notif.id, .SRCH);
+    };
+
+    const vfd0 = caller.fd_table.insert(file0, .{ .cloexec = cloexec }) catch {
+        file0.unref();
+        file1.unref();
+        logger.log("socketpair: failed to insert fd 0", .{});
+        return replyErr(notif.id, .MFILE);
+    };
+
+    const vfd1 = caller.fd_table.insert(file1, .{ .cloexec = cloexec }) catch {
+        _ = caller.fd_table.remove(vfd0);
+        file0.unref();
+        file1.unref();
+        logger.log("socketpair: failed to insert fd 1", .{});
+        return replyErr(notif.id, .MFILE);
+    };
+
+    // Write the virtual fds back to the caller's sv[2] array
+    const vfds = [2]i32{ vfd0, vfd1 };
+    memory_bridge.write([2]i32, caller_tid, vfds, sv_ptr) catch |err| {
+        _ = caller.fd_table.remove(vfd0);
+        _ = caller.fd_table.remove(vfd1);
+        file0.unref();
+        file1.unref();
+        logger.log("socketpair: failed to write fds to caller: {}", .{err});
+        return replyErr(notif.id, .FAULT);
+    };
+
+    logger.log("socketpair: created vfd0={d} vfd1={d}", .{ vfd0, vfd1 });
+    return replySuccess(notif.id, 0);
+}
+
+const testing = std.testing;
+const makeNotif = @import("../../../seccomp/notif.zig").makeNotif;
+const isError = @import("../../../seccomp/notif.zig").isError;
+const LogBuffer = @import("../../../LogBuffer.zig");
+const generateUid = @import("../../../setup.zig").generateUid;
+
+test "socketpair creates two virtual fds and writes them back" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    var sv: [2]i32 = .{ -1, -1 };
+
+    const notif = makeNotif(.socketpair, .{
+        .pid = init_tid,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM,
+        .arg2 = 0,
+        .arg3 = @intFromPtr(&sv),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(!isError(resp));
+    try testing.expectEqual(@as(i64, 0), resp.val);
+
+    // Both vfds should be >= 3
+    try testing.expect(sv[0] >= 3);
+    try testing.expect(sv[1] >= 3);
+    try testing.expect(sv[0] != sv[1]);
+
+    // Both should exist in the FdTable
+    const caller = supervisor.guest_threads.lookup.get(init_tid).?;
+    const ref0 = caller.fd_table.get_ref(sv[0]);
+    defer if (ref0) |f| f.unref();
+    try testing.expect(ref0 != null);
+
+    const ref1 = caller.fd_table.get_ref(sv[1]);
+    defer if (ref1) |f| f.unref();
+    try testing.expect(ref1 != null);
+}
+
+test "socketpair with SOCK_CLOEXEC sets cloexec flag" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    var sv: [2]i32 = .{ -1, -1 };
+
+    const notif = makeNotif(.socketpair, .{
+        .pid = init_tid,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM | linux.SOCK.CLOEXEC,
+        .arg2 = 0,
+        .arg3 = @intFromPtr(&sv),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(!isError(resp));
+
+    const caller = supervisor.guest_threads.lookup.get(init_tid).?;
+    try testing.expect(caller.fd_table.getCloexec(sv[0]));
+    try testing.expect(caller.fd_table.getCloexec(sv[1]));
+}
+
+test "socketpair unknown caller returns ESRCH" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    var sv: [2]i32 = .{ -1, -1 };
+
+    const notif = makeNotif(.socketpair, .{
+        .pid = 999,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM,
+        .arg2 = 0,
+        .arg3 = @intFromPtr(&sv),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.SRCH))), resp.@"error");
+}

--- a/src/core/virtual/syscall/syscalls.zig
+++ b/src/core/virtual/syscall/syscalls.zig
@@ -30,6 +30,8 @@ const chdir = @import("handlers/chdir.zig");
 const fchdir = @import("handlers/fchdir.zig");
 const faccessat = @import("handlers/faccessat.zig");
 const pipe2 = @import("handlers/pipe2.zig");
+const socket = @import("handlers/socket.zig");
+const socketpair = @import("handlers/socketpair.zig");
 
 pub inline fn handle(notif: linux.SECCOMP.notif, supervisor: *Supervisor) linux.SECCOMP.notif_resp {
     const sys: linux.SYS = @enumFromInt(notif.data.nr);
@@ -54,6 +56,8 @@ pub inline fn handle(notif: linux.SECCOMP.notif, supervisor: *Supervisor) linux.
         .fchdir => fchdir.handle(notif, supervisor),
         .faccessat => faccessat.handle(notif, supervisor),
         .pipe2 => pipe2.handle(notif, supervisor),
+        .socket => socket.handle(notif, supervisor),
+        .socketpair => socketpair.handle(notif, supervisor),
         // Implemented - process
         .getpid => getpid.handle(notif, supervisor),
         .getppid => getppid.handle(notif, supervisor),


### PR DESCRIPTION
Following the same pattern as pipe2 #32 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds socket and socketpair syscall handlers to create kernel sockets, wrap them as passthrough Files, and return virtual fds. Honors SOCK_CLOEXEC and integrates with the caller’s FdTable.

- **New Features**
  - socket: creates a kernel socket and returns a virtual fd.
  - socketpair: creates a pair and writes virtual fds back to sv[2] via memory_bridge.
  - Respects SOCK_CLOEXEC by setting the cloexec flag in the FdTable.
  - Robust cleanup and errno propagation (e.g., ESRCH for unknown thread, MFILE/NOMEM).
  - Wired into syscalls.zig and test imports; adds tests for success, CLOEXEC, and error paths.

<sup>Written for commit eaf82dacf4a790315f6e3e95f18bdf4faf89bd14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

