### PR TITLE
implemented connect and shutdown

### DIFF
--- a/src/core/main.zig
+++ b/src/core/main.zig
@@ -46,6 +46,8 @@ test {
     _ = @import("virtual/syscall/handlers/pipe2.zig");
     _ = @import("virtual/syscall/handlers/socket.zig");
     _ = @import("virtual/syscall/handlers/socketpair.zig");
+    _ = @import("virtual/syscall/handlers/connect.zig");
+    _ = @import("virtual/syscall/handlers/shutdown.zig");
     _ = @import("virtual/syscall/e2e_test.zig");
     _ = @import("virtual/OverlayRoot.zig");
     _ = @import("virtual/fs/backend/passthrough.zig");

--- a/src/core/virtual/fs/File.zig
+++ b/src/core/virtual/fs/File.zig
@@ -170,3 +170,15 @@ pub fn lseek(self: *Self, offset: i64, whence: u32) !i64 {
         .proc => |*f| return f.lseek(offset, whence),
     }
 }
+
+pub fn connect(self: *Self, addr: [*]const u8, addrlen: linux.socklen_t) !void {
+    switch (self.backend) {
+        inline else => |*f| return f.connect(addr, addrlen),
+    }
+}
+
+pub fn shutdown(self: *Self, how: i32) !void {
+    switch (self.backend) {
+        inline else => |*f| return f.shutdown(how),
+    }
+}

--- a/src/core/virtual/fs/backend/cow.zig
+++ b/src/core/virtual/fs/backend/cow.zig
@@ -107,6 +107,16 @@ pub const Cow = union(enum) {
         if (linux.errno(result) != .SUCCESS) return error.SyscallFailed;
         return @intCast(result);
     }
+
+    pub fn connect(self: *Cow, addr: [*]const u8, addrlen: linux.socklen_t) !void {
+        _ = .{ self, addr, addrlen };
+        return error.NotASocket;
+    }
+
+    pub fn shutdown(self: *Cow, how: i32) !void {
+        _ = .{ self, how };
+        return error.NotASocket;
+    }
 };
 
 /// Copy a file from src to dst using posix calls.

--- a/src/core/virtual/fs/backend/passthrough.zig
+++ b/src/core/virtual/fs/backend/passthrough.zig
@@ -64,6 +64,16 @@ pub const Passthrough = struct {
         if (linux.errno(result) != .SUCCESS) return error.SyscallFailed;
         return @intCast(result);
     }
+
+    pub fn connect(self: *Passthrough, addr: [*]const u8, addrlen: linux.socklen_t) !void {
+        const rc = linux.connect(self.fd, @ptrCast(addr), addrlen);
+        if (linux.errno(rc) != .SUCCESS) return error.SyscallFailed;
+    }
+
+    pub fn shutdown(self: *Passthrough, how: i32) !void {
+        const rc = linux.shutdown(self.fd, how);
+        if (linux.errno(rc) != .SUCCESS) return error.SyscallFailed;
+    }
 };
 
 const testing = std.testing;

--- a/src/core/virtual/fs/backend/procfile.zig
+++ b/src/core/virtual/fs/backend/procfile.zig
@@ -170,6 +170,16 @@ pub const ProcFile = struct {
         self.offset = @intCast(new_offset);
         return new_offset;
     }
+
+    pub fn connect(self: *ProcFile, addr: [*]const u8, addrlen: linux.socklen_t) !void {
+        _ = .{ self, addr, addrlen };
+        return error.NotASocket;
+    }
+
+    pub fn shutdown(self: *ProcFile, how: i32) !void {
+        _ = .{ self, how };
+        return error.NotASocket;
+    }
 };
 
 // ============================================================================

--- a/src/core/virtual/fs/backend/tmp.zig
+++ b/src/core/virtual/fs/backend/tmp.zig
@@ -69,6 +69,16 @@ pub const Tmp = struct {
         if (linux.errno(result) != .SUCCESS) return error.SyscallFailed;
         return @intCast(result);
     }
+
+    pub fn connect(self: *Tmp, addr: [*]const u8, addrlen: linux.socklen_t) !void {
+        _ = .{ self, addr, addrlen };
+        return error.NotASocket;
+    }
+
+    pub fn shutdown(self: *Tmp, how: i32) !void {
+        _ = .{ self, how };
+        return error.NotASocket;
+    }
 };
 
 // ============================================================================

--- a/src/core/virtual/syscall/handlers/connect.zig
+++ b/src/core/virtual/syscall/handlers/connect.zig
@@ -1,0 +1,179 @@
+const std = @import("std");
+const linux = std.os.linux;
+const Thread = @import("../../proc/Thread.zig");
+const AbsTid = Thread.AbsTid;
+const File = @import("../../fs/File.zig");
+const Supervisor = @import("../../../Supervisor.zig");
+const replySuccess = @import("../../../seccomp/notif.zig").replySuccess;
+const replyErr = @import("../../../seccomp/notif.zig").replyErr;
+const memory_bridge = @import("../../../utils/memory_bridge.zig");
+
+pub fn handle(notif: linux.SECCOMP.notif, supervisor: *Supervisor) linux.SECCOMP.notif_resp {
+    const logger = supervisor.logger;
+
+    // Parse args: connect(sockfd, addr, addrlen)
+    const caller_tid: AbsTid = @intCast(notif.pid);
+    const fd: i32 = @bitCast(@as(u32, @truncate(notif.data.arg0)));
+    const addr_ptr: u64 = notif.data.arg1;
+    const addrlen: u32 = @truncate(notif.data.arg2);
+
+    // Validate addrlen (sockaddr_storage max is 128)
+    if (addrlen == 0 or addrlen > 128) {
+        return replyErr(notif.id, .INVAL);
+    }
+
+    // Critical section: File lookup
+    var file: *File = undefined;
+    {
+        supervisor.mutex.lockUncancelable(supervisor.io);
+        defer supervisor.mutex.unlock(supervisor.io);
+
+        const caller = supervisor.guest_threads.get(caller_tid) catch |err| {
+            logger.log("connect: Thread not found for tid={d}: {}", .{ caller_tid, err });
+            return replyErr(notif.id, .SRCH);
+        };
+
+        file = caller.fd_table.get_ref(fd) orelse {
+            logger.log("connect: EBADF for fd={d}", .{fd});
+            return replyErr(notif.id, .BADF);
+        };
+    }
+    defer file.unref();
+
+    // Read sockaddr from guest memory
+    var addr_buf: [128]u8 = undefined;
+    memory_bridge.readSlice(addr_buf[0..addrlen], caller_tid, addr_ptr) catch {
+        return replyErr(notif.id, .FAULT);
+    };
+
+    file.connect(&addr_buf, addrlen) catch |err| {
+        return switch (err) {
+            error.NotASocket => replyErr(notif.id, .NOTSOCK),
+            else => replyErr(notif.id, .IO),
+        };
+    };
+
+    logger.log("connect: fd={d} success", .{fd});
+    return replySuccess(notif.id, 0);
+}
+
+const testing = std.testing;
+const makeNotif = @import("../../../seccomp/notif.zig").makeNotif;
+const isError = @import("../../../seccomp/notif.zig").isError;
+const LogBuffer = @import("../../../LogBuffer.zig");
+const generateUid = @import("../../../setup.zig").generateUid;
+const ProcFile = @import("../../fs/backend/procfile.zig").ProcFile;
+const socket_handler = @import("socket.zig");
+
+test "connect unknown caller returns ESRCH" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    var addr = std.mem.zeroes(linux.sockaddr.un);
+    const notif = makeNotif(.connect, .{
+        .pid = 999,
+        .arg0 = 3,
+        .arg1 = @intFromPtr(&addr),
+        .arg2 = @sizeOf(linux.sockaddr.un),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.SRCH))), resp.@"error");
+}
+
+test "connect invalid vfd returns EBADF" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    var addr = std.mem.zeroes(linux.sockaddr.un);
+    const notif = makeNotif(.connect, .{
+        .pid = init_tid,
+        .arg0 = 99,
+        .arg1 = @intFromPtr(&addr),
+        .arg2 = @sizeOf(linux.sockaddr.un),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.BADF))), resp.@"error");
+}
+
+test "connect on non-socket file returns ENOTSOCK" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    // Insert a proc file (not a socket)
+    const caller = supervisor.guest_threads.lookup.get(init_tid).?;
+    const proc_file = try ProcFile.open(caller, "/proc/self");
+    const vfd = try caller.fd_table.insert(try File.init(allocator, .{ .proc = proc_file }), .{});
+
+    var addr = std.mem.zeroes(linux.sockaddr.un);
+    const notif = makeNotif(.connect, .{
+        .pid = init_tid,
+        .arg0 = @as(u64, @bitCast(@as(i64, vfd))),
+        .arg1 = @intFromPtr(&addr),
+        .arg2 = @sizeOf(linux.sockaddr.un),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.NOTSOCK))), resp.@"error");
+}
+
+test "connect UDP socket to localhost succeeds" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    // Create a UDP socket via socket handler
+    const sock_notif = makeNotif(.socket, .{
+        .pid = init_tid,
+        .arg0 = linux.AF.INET,
+        .arg1 = linux.SOCK.DGRAM,
+        .arg2 = 0,
+    });
+    const sock_resp = socket_handler.handle(sock_notif, &supervisor);
+    try testing.expect(!isError(sock_resp));
+    const vfd: i32 = @intCast(sock_resp.val);
+
+    // UDP connect just sets the default destination, always succeeds
+    var addr = std.mem.zeroes(linux.sockaddr.in);
+    addr.family = linux.AF.INET;
+    addr.port = std.mem.nativeToBig(u16, 12345);
+    addr.addr = std.mem.nativeToBig(u32, 0x7f000001); // 127.0.0.1
+
+    const notif = makeNotif(.connect, .{
+        .pid = init_tid,
+        .arg0 = @as(u64, @bitCast(@as(i64, vfd))),
+        .arg1 = @intFromPtr(&addr),
+        .arg2 = @sizeOf(linux.sockaddr.in),
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(!isError(resp));
+    try testing.expectEqual(@as(i64, 0), resp.val);
+}

--- a/src/core/virtual/syscall/handlers/shutdown.zig
+++ b/src/core/virtual/syscall/handlers/shutdown.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+const linux = std.os.linux;
+const Thread = @import("../../proc/Thread.zig");
+const AbsTid = Thread.AbsTid;
+const File = @import("../../fs/File.zig");
+const Supervisor = @import("../../../Supervisor.zig");
+const replySuccess = @import("../../../seccomp/notif.zig").replySuccess;
+const replyErr = @import("../../../seccomp/notif.zig").replyErr;
+
+pub fn handle(notif: linux.SECCOMP.notif, supervisor: *Supervisor) linux.SECCOMP.notif_resp {
+    const logger = supervisor.logger;
+
+    // Parse args: shutdown(sockfd, how)
+    const caller_tid: AbsTid = @intCast(notif.pid);
+    const fd: i32 = @bitCast(@as(u32, @truncate(notif.data.arg0)));
+    const how: i32 = @bitCast(@as(u32, @truncate(notif.data.arg1)));
+
+    // Critical section: File lookup
+    var file: *File = undefined;
+    {
+        supervisor.mutex.lockUncancelable(supervisor.io);
+        defer supervisor.mutex.unlock(supervisor.io);
+
+        const caller = supervisor.guest_threads.get(caller_tid) catch |err| {
+            logger.log("shutdown: Thread not found for tid={d}: {}", .{ caller_tid, err });
+            return replyErr(notif.id, .SRCH);
+        };
+
+        file = caller.fd_table.get_ref(fd) orelse {
+            logger.log("shutdown: EBADF for fd={d}", .{fd});
+            return replyErr(notif.id, .BADF);
+        };
+    }
+    defer file.unref();
+
+    file.shutdown(how) catch |err| {
+        return switch (err) {
+            error.NotASocket => replyErr(notif.id, .NOTSOCK),
+            else => replyErr(notif.id, .IO),
+        };
+    };
+
+    logger.log("shutdown: fd={d} how={d} success", .{ fd, how });
+    return replySuccess(notif.id, 0);
+}
+
+const testing = std.testing;
+const makeNotif = @import("../../../seccomp/notif.zig").makeNotif;
+const isError = @import("../../../seccomp/notif.zig").isError;
+const LogBuffer = @import("../../../LogBuffer.zig");
+const generateUid = @import("../../../setup.zig").generateUid;
+const memory_bridge = @import("../../../utils/memory_bridge.zig");
+const socketpair_handler = @import("socketpair.zig");
+
+test "shutdown unknown caller returns ESRCH" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    const notif = makeNotif(.shutdown, .{
+        .pid = 999,
+        .arg0 = 3,
+        .arg1 = linux.SHUT.RD,
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.SRCH))), resp.@"error");
+}
+
+test "shutdown invalid vfd returns EBADF" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    const notif = makeNotif(.shutdown, .{
+        .pid = init_tid,
+        .arg0 = 99,
+        .arg1 = linux.SHUT.RD,
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(isError(resp));
+    try testing.expectEqual(-@as(i32, @intCast(@intFromEnum(linux.E.BADF))), resp.@"error");
+}
+
+test "shutdown on socketpair succeeds" {
+    const allocator = testing.allocator;
+    const init_tid: AbsTid = 100;
+    var stdout_buf = LogBuffer.init(allocator);
+    var stderr_buf = LogBuffer.init(allocator);
+    defer stdout_buf.deinit();
+    defer stderr_buf.deinit();
+    var supervisor = try Supervisor.init(allocator, testing.io, generateUid(), -1, init_tid, &stdout_buf, &stderr_buf);
+    defer supervisor.deinit();
+
+    // Create a socketpair
+    var sv: [2]i32 = .{ -1, -1 };
+    const sp_notif = makeNotif(.socketpair, .{
+        .pid = init_tid,
+        .arg0 = linux.AF.UNIX,
+        .arg1 = linux.SOCK.STREAM,
+        .arg2 = 0,
+        .arg3 = @intFromPtr(&sv),
+    });
+    const sp_resp = socketpair_handler.handle(sp_notif, &supervisor);
+    try testing.expect(!isError(sp_resp));
+
+    // Shutdown one end for writing
+    const notif = makeNotif(.shutdown, .{
+        .pid = init_tid,
+        .arg0 = @as(u64, @bitCast(@as(i64, sv[0]))),
+        .arg1 = linux.SHUT.WR,
+    });
+
+    const resp = handle(notif, &supervisor);
+    try testing.expect(!isError(resp));
+    try testing.expectEqual(@as(i64, 0), resp.val);
+}


### PR DESCRIPTION
both simple operations on FDs, specifically through the Passthrough backend (error.NotASocket otherwise)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implemented connect(2) and shutdown(2) for virtual FDs to support outbound networking through the Passthrough backend. Non-socket FDs return ENOTSOCK, and server-side socket syscalls remain blocked.

- **New Features**
  - Added syscall handlers for connect and shutdown with arg validation and guest sockaddr reads; maps errors to errno.
  - File forwards connect/shutdown to backend implementations.
  - Passthrough implements linux.connect/shutdown; cow/procfile/tmp return NotASocket.
  - Dispatcher routes connect/shutdown; bind/listen/accept/accept4 now return EPERM.
  - Tests cover ESRCH, EBADF, ENOTSOCK, and success cases (UDP connect, socketpair shutdown).

<sup>Written for commit 7c9dffec8fd808210894ad19b973168efdc966a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

