### PR TITLE
0.0.6

### DIFF
--- a/src/sdks/node/package-lock.json
+++ b/src/sdks/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bvisor",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bvisor",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "workspaces": [
         "platforms/*"
       ],
@@ -95,7 +95,7 @@
     },
     "platforms/linux-arm64-gnu": {
       "name": "@bvisor/linux-arm64-gnu",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "cpu": [
         "arm64"
       ],
@@ -105,7 +105,7 @@
     },
     "platforms/linux-arm64-musl": {
       "name": "@bvisor/linux-arm64-musl",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "cpu": [
         "arm64"
       ],
@@ -115,7 +115,7 @@
     },
     "platforms/linux-x64-gnu": {
       "name": "@bvisor/linux-x64-gnu",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "cpu": [
         "x64"
       ],
@@ -125,7 +125,7 @@
     },
     "platforms/linux-x64-musl": {
       "name": "@bvisor/linux-x64-musl",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "cpu": [
         "x64"
       ],

--- a/src/sdks/node/package.json
+++ b/src/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bvisor",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -18,9 +18,8 @@
     "build": "tsc",
     "build:zig": "cd ../../.. && zig build -Doptimize=ReleaseSafe",
     "prepublishOnly": "npm run build",
-    "test:published": "docker run --rm -v ./test.ts:/test.ts:ro oven/bun:alpine sh -c 'cd /tmp && echo {} > package.json && bun add bvisor && cp /test.ts . && bun test.ts'",
     "version:patch": "npm version patch --workspaces --no-git-tag-version --force && npm version patch --no-git-tag-version --force",
-    "publish:all": "npm run build:zig && cd platforms/linux-arm64-musl && bun publish --access public && cd ../linux-arm64-gnu && bun publish --access public && cd ../linux-x64-musl && bun publish --access public && cd ../linux-x64-gnu && bun publish --access public && cd ../.. && bun publish --access public"
+    "publish:all": "npm run build:zig && bun scripts/publish.ts"
   },
   "workspaces": [
     "platforms/*"

--- a/src/sdks/node/platforms/linux-arm64-gnu/package.json
+++ b/src/sdks/node/platforms/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bvisor/linux-arm64-gnu",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "os": [
     "linux"
   ],

--- a/src/sdks/node/platforms/linux-arm64-musl/package.json
+++ b/src/sdks/node/platforms/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bvisor/linux-arm64-musl",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "os": [
     "linux"
   ],

--- a/src/sdks/node/platforms/linux-x64-gnu/package.json
+++ b/src/sdks/node/platforms/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bvisor/linux-x64-gnu",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "os": [
     "linux"
   ],

--- a/src/sdks/node/platforms/linux-x64-musl/package.json
+++ b/src/sdks/node/platforms/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bvisor/linux-x64-musl",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "os": [
     "linux"
   ],

--- a/src/sdks/node/scripts/publish.ts
+++ b/src/sdks/node/scripts/publish.ts
@@ -1,0 +1,42 @@
+import { readFileSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
+
+const pkgPath = new URL("../package.json", import.meta.url).pathname;
+const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+const version = pkg.version;
+
+const platforms = [
+  "linux-arm64-musl",
+  "linux-arm64-gnu",
+  "linux-x64-musl",
+  "linux-x64-gnu",
+];
+
+// Publish platform packages first
+for (const platform of platforms) {
+  console.log(`Publishing @bvisor/${platform}...`);
+  execSync("bun publish --access public", {
+    cwd: new URL(`../platforms/${platform}`, import.meta.url).pathname,
+    stdio: "inherit",
+  });
+}
+
+// Pin optionalDependencies to the current version for publishing
+for (const key of Object.keys(pkg.optionalDependencies)) {
+  pkg.optionalDependencies[key] = version;
+}
+writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+
+try {
+  console.log(`Publishing bvisor@${version}...`);
+  execSync("bun publish --access public", {
+    cwd: new URL("..", import.meta.url).pathname,
+    stdio: "inherit",
+  });
+} finally {
+  // Restore workspace:* for local dev
+  for (const key of Object.keys(pkg.optionalDependencies)) {
+    pkg.optionalDependencies[key] = "workspace:*";
+  }
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+}

--- a/src/sdks/node/test.ts
+++ b/src/sdks/node/test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Sandbox } from "bvisor";
 
 const isInteractive = Bun.argv.includes("--interactive");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automated the Node SDK publish workflow and bumped all packages to 0.0.6. Publishing now runs platform packages first and pins optionalDependencies to the release version for a consistent publish.

- **New Features**
  - Added scripts/publish.ts to publish platform packages first, then the main package.
  - Temporarily pins optionalDependencies to the current version during publish, restoring workspace:* afterward.

- **Refactors**
  - Replaced publish:all with bun scripts/publish.ts and removed the docker-based test:published script.
  - Added // @ts-nocheck to test.ts to avoid Bun type issues.

<sup>Written for commit 461759a1e54f88cd8501e51d812102b2c562dd09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

